### PR TITLE
BUG: Fix mirror filter implementation

### DIFF
--- a/SurfaceToolbox/SurfaceToolbox.py
+++ b/SurfaceToolbox/SurfaceToolbox.py
@@ -830,9 +830,9 @@ class SurfaceToolboxLogic(ScriptedLoadableModuleLogic):
 
       parameters = {"inputVolume": state.parameterNode.GetParameter("outputVolume"),
                     "outputVolume": state.parameterNode.GetParameter("outputVolume"),
-                    "xAxis": bool(state.parameterNode.GetParameter("MirrorxAxis")),
-                    "yAxis": bool(state.parameterNode.GetParameter("MirroryAxis")),
-                    "zAxis": bool(state.parameterNode.GetParameter("MirrorzAxis"))}
+                    "xAxis": bool(state.parameterNode.GetParameter("MirrorxAxis") == "True"),
+                    "yAxis": bool(state.parameterNode.GetParameter("MirroryAxis") == "True"),
+                    "zAxis": bool(state.parameterNode.GetParameter("MirrorzAxis") == "True")}
       mirrorMaker = slicer.modules.mirror
       slicer.cli.runSync(mirrorMaker, None, parameters)
       surface = state.outputModelNode.GetPolyDataConnection()


### PR DESCRIPTION
This commit re-use the SurfaceToolbox implementation originally
integrated in 2d242ccd (ENH: Add mirror and normals auto-orient to Surface Toolbox)

Co-authored-by: Beatriz Paniagua <beatriz.paniagua@kitware.com>