### PR TITLE
ENH: Add repeatable input nodes to Dynamic Modeler

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerLogic.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerLogic.cxx
@@ -240,10 +240,16 @@ void vtkSlicerDynamicModelerLogic::UpdateDynamicModelerRule(vtkMRMLDynamicModele
       for (int i = 0; i < rule->GetNumberOfInputNodes(); ++i)
         {
         std::string referenceRole = rule->GetNthInputNodeReferenceRole(i);
-        const char* referenceId = surfaceEditorNode->GetNodeReferenceID(referenceRole.c_str());
-        // Current behavior is to add back references without observers
-        // This preserves the selected nodes for each rule
-        surfaceEditorNode->SetNodeReferenceID(referenceRole.c_str(), referenceId);
+        std::vector<const char*> referenceNodeIds;
+        surfaceEditorNode->GetNodeReferenceIDs(referenceRole.c_str(), referenceNodeIds);
+        int referenceIndex = 0;
+        for (const char* referenceId : referenceNodeIds)
+          {
+          // Current behavior is to add back references without observers
+          // This preserves the selected nodes for each rule
+          surfaceEditorNode->SetNthNodeReferenceID(referenceRole.c_str(), referenceIndex, referenceId);
+          ++referenceIndex;
+          }
         }
       }
 
@@ -262,14 +268,17 @@ void vtkSlicerDynamicModelerLogic::UpdateDynamicModelerRule(vtkMRMLDynamicModele
     for (int i = 0; i < rule->GetNumberOfInputNodes(); ++i)
       {
       std::string referenceRole = rule->GetNthInputNodeReferenceRole(i);
-      vtkMRMLNode* node = surfaceEditorNode->GetNodeReference(referenceRole.c_str());
-      if (!node)
-        {
-        continue;
-        }
-
+      std::vector<const char*> referenceNodeIds;
+      surfaceEditorNode->GetNodeReferenceIDs(referenceRole.c_str(), referenceNodeIds);
       vtkIntArray* events = rule->GetNthInputNodeEvents(i);
-      surfaceEditorNode->SetAndObserveNodeReferenceID(referenceRole.c_str(), node->GetID(), events);
+      int referenceIndex = 0;
+      for (const char* referenceId : referenceNodeIds)
+        {
+        // Current behavior is to add back references without observers
+        // This preserves the selected nodes for each rule
+        surfaceEditorNode->SetAndObserveNthNodeReferenceID(referenceRole.c_str(), referenceIndex, referenceId, events);
+        ++referenceIndex;
+        }
       }
     }
 }

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutRule.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutRule.h
@@ -32,13 +32,15 @@
 #include <string>
 #include <vector>
 
-class vtkClipClosedSurface;
 class vtkClipPolyData;
 class vtkDataObject;
 class vtkGeneralTransform;
 class vtkGeometryFilter;
+class vtkImplicitBoolean;
+class vtkImplicitFunction;
 class vtkMRMLDynamicModelerNode;
 class vtkPlane;
+class vtkPlaneCollection;
 class vtkPolyData;
 class vtkThreshold;
 class vtkTransformPolyDataFilter;
@@ -61,7 +63,8 @@ public:
   /// Run the plane cut on the input model node
   bool RunInternal(vtkMRMLDynamicModelerNode* surfaceEditorNode) override;
 
-  void CreateEndCap(vtkPolyData* surface);
+  /// Create an end cap on the clipped surface
+  void CreateEndCap(vtkPolyData* clippedSurface, vtkPlaneCollection* planes, vtkPolyData* originalPolyData, vtkImplicitFunction* cutFunction);
 
 protected:
   vtkSlicerDynamicModelerPlaneCutRule();
@@ -72,11 +75,7 @@ protected:
   vtkSmartPointer<vtkTransformPolyDataFilter> InputModelToWorldTransformFilter;
   vtkSmartPointer<vtkGeneralTransform>        InputModelNodeToWorldTransform;
 
-  vtkSmartPointer<vtkClipClosedSurface>       PlaneClipper;
-  vtkSmartPointer<vtkPlane>                   Plane;
-
-  vtkSmartPointer<vtkThreshold>               ThresholdFilter;
-  vtkSmartPointer<vtkGeometryFilter>          GeometryFilter;
+  vtkSmartPointer<vtkClipPolyData>            PlaneClipper;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> OutputPositiveModelToWorldTransformFilter;
   vtkSmartPointer<vtkGeneralTransform>        OutputPositiveWorldToModelTransform;

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerRule.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerRule.cxx
@@ -115,6 +115,16 @@ bool vtkSlicerDynamicModelerRule::GetNthInputNodeRequired(int n)
   return this->InputNodeInfo[n].Required;
 }
 
+//----------------------------------------------------------------------------
+bool vtkSlicerDynamicModelerRule::GetNthInputNodeRepeatable(int n)
+{
+  if (n >= this->InputNodeInfo.size())
+    {
+    vtkErrorMacro("Input node " << n << " is out of range!");
+    return false;
+    }
+  return this->InputNodeInfo[n].Repeatable;
+}
 
 //----------------------------------------------------------------------------
 std::string vtkSlicerDynamicModelerRule::GetNthOutputNodeName(int n)
@@ -282,6 +292,17 @@ vtkVariant vtkSlicerDynamicModelerRule::GetNthInputParameterValue(int n, vtkMRML
     return this->InputParameterInfo[n].DefaultValue;
     }
   return vtkVariant(parameterValue);
+}
+
+//---------------------------------------------------------------------------
+vtkStringArray* vtkSlicerDynamicModelerRule::GetNthInputParameterPossibleValues(int n)
+{
+  if (n >= this->InputParameterInfo.size())
+    {
+    vtkErrorMacro("Parameter " << n << " is out of range!");
+    return nullptr;
+    }
+  return this->InputParameterInfo[n].PossibleValues;
 }
 
 //---------------------------------------------------------------------------

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerRule.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerRule.h
@@ -93,6 +93,9 @@ public:
   /// Returns true if the input is required for the rule to be run.
   bool GetNthInputNodeRequired(int n);
 
+  /// Returns true if the input is repeatable
+  bool GetNthInputNodeRepeatable(int n);
+
   /// Returns the events that must be observed to enable continuous updates for the current input.
   vtkIntArray* GetNthInputNodeEvents(int n);
 
@@ -132,6 +135,10 @@ public:
   /// Returns the value of the Nth input parameter from the parameter node.
   vtkVariant GetNthInputParameterValue(int n, vtkMRMLDynamicModelerNode* surfaceEditorNode);
 
+  /// Returns the possible values of the Nth input parameter.
+  /// Only used for string enum types
+  vtkStringArray* GetNthInputParameterPossibleValues(int n);
+
   /// Returns true if all of the required inputs have been specified for the surface editor node.
   virtual bool HasRequiredInputs(vtkMRMLDynamicModelerNode* surfaceEditorNode);
 
@@ -142,6 +149,7 @@ public:
   enum ParameterType
   {
     PARAMETER_STRING,
+    PARAMETER_STRING_ENUM,
     PARAMETER_BOOL,
     PARAMETER_INT,
     PARAMETER_DOUBLE,
@@ -160,12 +168,13 @@ protected:
   /// Struct containing all of the relevant info for input and output nodes.
   struct StructNodeInfo
   {
-    StructNodeInfo(std::string name, std::string description, vtkStringArray* classNames, std::string referenceRole, bool required, vtkIntArray* events = nullptr)
+    StructNodeInfo(std::string name, std::string description, vtkStringArray* classNames, std::string referenceRole, bool required, bool repeatable, vtkIntArray* events = nullptr)
       : Name(name)
       , Description(description)
       , ClassNames(classNames)
       , ReferenceRole(referenceRole)
       , Required(required)
+      , Repeatable(repeatable)
       , Events(events)
     {
     }
@@ -174,6 +183,7 @@ protected:
     vtkSmartPointer<vtkStringArray> ClassNames;
     std::string                     ReferenceRole;
     bool                            Required;
+    bool                            Repeatable;
     vtkSmartPointer<vtkIntArray>    Events;
   };
   using NodeInfo = struct StructNodeInfo;
@@ -196,6 +206,7 @@ protected:
     std::string AttributeName;
     int Type{ PARAMETER_STRING };
     vtkVariant DefaultValue;
+    vtkSmartPointer<vtkStringArray> PossibleValues;
   };
   using ParameterInfo = struct StructParameterInfo;
   std::vector<ParameterInfo> InputParameterInfo;

--- a/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.cxx
+++ b/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.cxx
@@ -14,10 +14,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
-  and was supported through the Applied Cancer Research Unit program of Cancer Care
-  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
-
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
 ==============================================================================*/
 
 // SubjectHierarchy MRML includes

--- a/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.h
+++ b/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.h
@@ -14,9 +14,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
-  and was supported through the Applied Cancer Research Unit program of Cancer Care
-  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
 
 ==============================================================================*/
 
@@ -84,9 +84,9 @@ public:
   void setDynamicModelerLogic(vtkSlicerDynamicModelerLogic* dynamicModelerLogic);
 
 protected slots:
-  /// TODO
+  /// Toggle continuous update of the rule
   void continuousUpdateChanged();
-  /// TODO
+  /// Trigger a single update of the rule
   void updateTriggered();
 
 protected:

--- a/DynamicModeler/qSlicerDynamicModelerModuleWidget.h
+++ b/DynamicModeler/qSlicerDynamicModelerModuleWidget.h
@@ -43,7 +43,8 @@ public:
   ~qSlicerDynamicModelerModuleWidget() override;
 
 public:
-  // TODO
+  /// Add a rule button to the top of the widget.
+  /// The button will create a new node using the rule when clicked.
   void addRuleButton(QIcon icon, vtkSlicerDynamicModelerRule* rule);
 
 protected:


### PR DESCRIPTION
Input nodes for vtkSlicerDynamicModelerRule are now repeatable by setting the Repeatable boolean to True.
The module widget will automatically add additional input node selectors if all of them are filled, and remove extra ones if there are more than 1 combobox with no node selected.

Also update vtkSlicerDynamicModelerPlaneCutRule to take advantage of this by allowing the specification of N planes, instead of just one. Planes can be combined through union, intersection or difference operations.