### PR TITLE
ENH: Set scalar values for each region when using Boundary Cut

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.h
@@ -41,7 +41,9 @@ class vtkGeometryFilter;
 class vtkImplicitBoolean;
 class vtkMRMLDynamicModelerNode;
 class vtkPlane;
+class vtkPointLocator;
 class vtkPolyData;
+class vtkPolyDataConnectivityFilter;
 class vtkReverseSense;
 class vtkThreshold;
 class vtkTransform;
@@ -71,17 +73,28 @@ protected:
   ~vtkSlicerDynamicModelerBoundaryCutTool() override;
   void operator=(const vtkSlicerDynamicModelerBoundaryCutTool&);
 
-  void GetPositionForClosestPointRegion(vtkMRMLDynamicModelerNode* surfaceEditorNode, double closestPointRegion_World[3]);
+  /// Populates the list of seed points corresponding to the regions to be extracted.
+  virtual void GetSeedPoints(vtkMRMLDynamicModelerNode* surfaceEditorNode, vtkPoints* points);
+
+  /// The default seed point location. Calculated from the center of all input control points
+  virtual void GetDefaultSeedPoint(vtkMRMLDynamicModelerNode* surfaceEditorNode, double seedPoint[3]);
+
+  /// Sets the CellData scalars according to which region each cell belongs to.
+  /// Seed scalars start at 1 and are incremented by 1 for each seed.
+  virtual void ColorOutputRegions(vtkPoints* seedPoints);
 
 protected:
-  vtkSmartPointer<vtkGeneralTransform>        InputModelToWorldTransform;
-  vtkSmartPointer<vtkTransformPolyDataFilter> InputModelToWorldTransformFilter;
+  vtkSmartPointer<vtkGeneralTransform>           InputModelToWorldTransform;
+  vtkSmartPointer<vtkTransformPolyDataFilter>    InputModelToWorldTransformFilter;
 
-  vtkSmartPointer<vtkClipPolyData>            ClipPolyData;
-  vtkSmartPointer<vtkConnectivityFilter>      Connectivity;
+  vtkSmartPointer<vtkClipPolyData>               ClipPolyData;
+  vtkSmartPointer<vtkPolyDataConnectivityFilter> Connectivity;
+  vtkSmartPointer<vtkConnectivityFilter>         ColorConnectivity;
 
-  vtkSmartPointer<vtkGeneralTransform>        OutputWorldToModelTransform;
-  vtkSmartPointer<vtkTransformPolyDataFilter> OutputWorldToModelTransformFilter;
+  vtkSmartPointer<vtkGeneralTransform>           OutputWorldToModelTransform;
+  vtkSmartPointer<vtkTransformPolyDataFilter>    OutputWorldToModelTransformFilter;
+
+  vtkSmartPointer<vtkPointLocator>               ClippedModelPointLocator;
 };
 
 #endif // __vtkSlicerDynamicModelerBoundaryCutTool_h


### PR DESCRIPTION
When using boundary cut with multiple fiducials, the "RegionId" CellData scalar array is used to identify which regions belong to which fiducial.

Region numbering starts at 1 and is incremented by 1 for each fiducial:
Index 0 -> 1
Index 1 -> 2
etc.

Re: #30