### PR TITLE
COMP: Fix -Wunused-variable warnings in qSlicerDynamicModelerModuleWidget

### DIFF
--- a/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx
+++ b/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx
@@ -678,8 +678,6 @@ void qSlicerDynamicModelerModuleWidget::updateMRMLFromWidget()
   for (qMRMLNodeComboBox* inputNodeSelector : inputNodeSelectors)
     {
     QString referenceRole = inputNodeSelector->property("ReferenceRole").toString();
-    int inputIndex = inputNodeSelector->property("InputIndex").toInt();
-    int inputSelectorIndex = inputNodeSelector->property("InputSelectorIndex").toInt();
     QString currentNodeID = inputNodeSelector->currentNodeID();
     d->DynamicModelerNode->AddNodeReferenceID(referenceRole.toUtf8(), currentNodeID.toUtf8());
     }


### PR DESCRIPTION
This commit fixes the following warnings:

```
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx: In member function ‘void qSlicerDynamicModelerModuleWidget::updateMRMLFromWidget()’:
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx:681:9: warning: unused variable ‘inputIndex’ [-Wunused-variable]
       int inputIndex = inputNodeSelector->property("InputIndex").toInt();
           ^
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx:682:9: warning: unused variable ‘inputSelectorIndex’ [-Wunused-variable]
       int inputSelectorIndex = inputNodeSelector->property("InputSelectorIndex").toInt();
           ^
```