### PR TITLE
BUG: Fix issue showing incorrect number of repeatable inputs

### DIFF
--- a/DynamicModeler/qSlicerDynamicModelerModuleWidget.h
+++ b/DynamicModeler/qSlicerDynamicModelerModuleWidget.h
@@ -52,9 +52,11 @@ protected:
 
   void setup() override;
 
-  void resetInputWidgets();
-  void resetParameterWidgets();
-  void resetOutputWidgets();
+  bool isInputWidgetsRebuildRequired();
+
+  void rebuildInputWidgets();
+  void rebuildParameterWidgets();
+  void rebuildOutputWidgets();
 
   void updateInputWidgets();
   void updateParameterWidgets();


### PR DESCRIPTION
Sometimes when switching between two dynamic modeler nodes, the number of widgets for repeatable inputs would be incorrect.
Fixed by creating a function to explicitly check that the number of input widgets is always equal to the existing node references (+1 additional selector for repeatable inputs.

The index of repeatable inputs displayed on the GUI now starts at [1].