### PR TITLE
BUG: Fix plane cut cap orientation for negative side

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.h
@@ -64,7 +64,7 @@ public:
   bool RunInternal(vtkMRMLDynamicModelerNode* surfaceEditorNode) override;
 
   /// Create an end cap on the clipped surface
-  void CreateEndCap(vtkPolyData* clippedSurface, vtkPlaneCollection* planes, vtkPolyData* originalPolyData, vtkImplicitBoolean* cutFunction);
+  void CreateEndCap(vtkPolyData* clippedSurface, vtkPlaneCollection* planes, vtkPolyData* originalPolyData, vtkImplicitBoolean* cutFunction, vtkPolyData* outputEndCap);
 
 protected:
   vtkSlicerDynamicModelerPlaneCutTool();


### PR DESCRIPTION
Previously, the cap normal direction of the negative plane cut model was reversed.
CreateEndCap was also called twice (once each for positive and negative sides), even though it generated the same polygons for both sides.

CreateEndCap is now called once to create the cap for the positive side. The positive cap is appended to the positive side as normal. The normals and cells of the positive cap are now flipped using vtkReverseSense before they are appended to the negative side.

Re Slicer/Slicer#5359