### PR TITLE
COMP: Update DynamicModeler/Logic/FastMarching to support VTK8

### DIFF
--- a/DynamicModeler/Logic/FastMarching/vtkFastMarchingGeodesicDistance.cxx
+++ b/DynamicModeler/Logic/FastMarching/vtkFastMarchingGeodesicDistance.cxx
@@ -222,8 +222,11 @@ void vtkFastMarchingGeodesicDistance::SetupGeodesicMesh( vtkPolyData *in )
       point.SetPosition( GW::GW_Vector3D( pt[0], pt[1], pt[2] ) );
       mesh->SetVertex( i, &point );
       }
-
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
     const vtkIdType* ptIds = nullptr;
+#else
+    vtkIdType *ptIds = nullptr;
+#endif
     vtkIdType npts = 0;
     const int nCells = in->GetNumberOfPolys();
     vtkCellArray *cells = in->GetPolys();

--- a/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx
+++ b/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx
@@ -22,6 +22,7 @@
 #include "vtkFastMarchingGeodesicPath.h"
 #include "vtkSmartPointer.h"
 #include "vtkNew.h"
+#include "vtkVersion.h"
 
 vtkStandardNewMacro(vtkPolygonalSurfaceContourLineInterpolator2);
 
@@ -143,12 +144,7 @@ int vtkPolygonalSurfaceContourLineInterpolator2::InterpolateLine(
     {
     // Compute the shortest path through the surface mesh along its edges
     // using Dijkstra.
-
-#if (VTK_MAJOR_VERSION < 6)
-    dggp->SetInput( nodeBegin->PolyData );
-#else
     dggp->SetInputData( nodeBegin->PolyData );
-#endif
     dggp->SetStartVertex( endVertId );
     dggp->SetEndVertex( beginVertId );
     dggp->Update();
@@ -157,12 +153,7 @@ int vtkPolygonalSurfaceContourLineInterpolator2::InterpolateLine(
   else // fast marching
     {
     // Compute the shortest path through the surface mesh using fast marching
-
-#if (VTK_MAJOR_VERSION < 6)
-    fmgp->SetInput( nodeBegin->PolyData );
-#else
     fmgp->SetInputData( nodeBegin->PolyData );
-#endif
     fmgp->SetBeginPointId( beginVertId );
     vtkNew< vtkIdList > destinationSeeds;
     destinationSeeds->InsertNextId( endVertId );
@@ -193,7 +184,11 @@ int vtkPolygonalSurfaceContourLineInterpolator2::InterpolateLine(
   vtkPolyData *pd = this->GeodesicPath->GetOutput();
 
   // We assume there's only one cell of course
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
   const vtkIdType* pts = nullptr;
+#else
+  vtkIdType* pts = nullptr;
+#endif
   vtkIdType npts = 0;
   pd->GetLines()->InitTraversal();
   pd->GetLines()->GetNextCell( npts, pts);


### PR DESCRIPTION
This commit fixes the following errors reported when building against VTK8:                      

```
  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:148:11: error: no member named 'SetInput' in
        'vtkDijkstraGraphGeodesicPath'
      dggp->SetInput( nodeBegin->PolyData );
      ~~~~  ^

  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:162:11: error: no member named 'SetInput' in
        'vtkFastMarchingGeodesicPath'
      fmgp->SetInput( nodeBegin->PolyData );
      ~~~~  ^

  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:199:19: error: no matching member function for call to
        'GetNextCell'
    pd->GetLines()->GetNextCell( npts, pts);
    ~~~~~~~~~~~~~~~~^~~~~~~~~~~
```