### PR TITLE
BUG: Fix Dynamic Modeler boundary cut with plane

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.cxx
@@ -222,7 +222,7 @@ bool vtkSlicerDynamicModelerBoundaryCutTool::RunInternal(vtkMRMLDynamicModelerNo
     vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(inputNode);
     if (planeNode)
       {
-      if (planeNode->GetNumberOfControlPoints() < 3)
+      if (!planeNode->GetIsPlaneValid())
         {
         continue;
         }


### PR DESCRIPTION
Plane nodes are now no longer always defined by 3 control points.
Instead use GetIsPlaneValid to determine if a plane is valid.