### PR TITLE
COMP: Remove use of deprecated vtkThreshold API

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx
@@ -364,7 +364,8 @@ bool vtkSlicerDynamicModelerSelectByPointsTool::UpdateUsingSphereRadius(vtkPolyD
 
     vtkNew<vtkThreshold> thresholdFilter;
     thresholdFilter->SetInputData(inputMesh_WorldWithSelection);
-    thresholdFilter->ThresholdByUpper(0.5);
+    thresholdFilter->SetUpperThreshold(0.5);
+    thresholdFilter->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
     thresholdFilter->SetInputArrayToProcess(0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, SELECTION_ARRAY_NAME);
     thresholdFilter->Update();
     vtkNew<vtkGeometryFilter> geometryFilter;


### PR DESCRIPTION
This commit fixes the following warnings by removing use of API deprecated
in kitware/vtk@62e5a71bf (Add setters to vtkThreshold).

Warnings:

```
    /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx: In member function ‘bool vtkSlicerDynamicModelerSelectByPointsTool::UpdateUsingSphereRadius(vtkPolyData*, vtkMRMLMarkupsFiducialNode*, double, bool, bool, vtkUnsignedCharArray*, vtkSmartPointer<vtkPolyData>&)’:
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx:367:42: warning: ‘void vtkThreshold::ThresholdByUpper(double)’ is deprecated: Use 'SetUpperThreshold' and 'SetThresholdFunction' instead. [-Wdeprecated-declarations]
    367 |     thresholdFilter->ThresholdByUpper(0.5);
        |                                          ^
  In file included from /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx:40:
  /path/to/Slicer-Release/VTK/Filters/Core/vtkThreshold.h:95:8: note: declared here
     95 |   void ThresholdByUpper(double upper);
        |        ^~~~~~~~~~~~~~~~
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx: In member function ‘bool vtkSlicerDynamicModelerSelectByPointsTool::UpdateUsingGeodesicDistance(vtkPolyData*, vtkMRMLMarkupsFiducialNode*, double, bool, bool, vtkUnsignedCharArray*, vtkSmartPointer<vtkPolyData>&)’:
  /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx:422:63: warning: ‘void vtkThreshold::ThresholdBetween(double, double)’ is deprecated: Use 'SetLowerThreshold', 'SetUpperThreshold' and 'SetThresholdFunction' instead. [-Wdeprecated-declarations]
    422 |     thresholdFilter->ThresholdBetween(-1e-5, selectionDistance);
        |                                                               ^
  In file included from /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx:40:
  /path/to/Slicer-Release/VTK/Filters/Core/vtkThreshold.h:103:8: note: declared here
    103 |   void ThresholdBetween(double lower, double upper);
        |        ^~~~~~~~~~~~~~~~
```