### PR TITLE
COMP: Fix -Wdeprecated-copy in Simplify.h reported with gcc 9.x

### DIFF
--- a/Decimation/Simplify.h
+++ b/Decimation/Simplify.h
@@ -45,6 +45,9 @@ struct vec3f
     inline vec3f( vector3 a )
      { x = a.x; y = a.y; z = a.z; }
 
+    inline vec3f( const vec3f & a )
+    { x = a.x; y = a.y; z = a.z; }
+
     inline vec3f( const double X, const double Y, const double Z )
     { x = X; y = Y; z = Z; }
 


### PR DESCRIPTION
This commit addresses -Wdeprecated-copy warnings described below.

> -Wdeprecated-copy (C++ and Objective-C++ only)
>
>   Warn that the implicit declaration of a copy constructor or
>   copy assignment operator is deprecated if the class has a
>   user-provided copy constructor or copy assignment operator,
>   in C++11 and up. This warning is enabled by -Wextra.
>   With -Wdeprecated-copy-dtor, also deprecate if the class has
>   a user-provided destructor.
>

Source:
* https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy
* https://www.gnu.org/software/gcc/gcc-9/changes.html

Example of warning:

```
  In file included from /path/to/Slicer-Release/SurfaceToolbox/Decimation/Decimation.cxx:16:
  /path/to/Slicer-Release/SurfaceToolbox/Decimation/Simplify.h: In member function ‘vec3f vec3f::operator=(vector3)’:
  /path/to/Slicer-Release/SurfaceToolbox/Decimation/Simplify.h:67:33: warning: implicitly-declared ‘constexpr vec3f::vec3f(const vec3f&)’ is deprecated [-Wdeprecated-copy]
     67 |     { x=a.x;y=a.y;z=a.z;return *this; }
        |                                 ^~~~
```