### PR TITLE
COMP: Remove use of deprecated vtkThreshold API

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx
@@ -420,7 +420,9 @@ bool vtkSlicerDynamicModelerSelectByPointsTool::UpdateUsingGeodesicDistance(vtkP
     {
     vtkNew<vtkThreshold> thresholdFilter;
     thresholdFilter->SetInputData(this->GeodesicDistance->GetOutput());
-    thresholdFilter->ThresholdBetween(-1e-5, selectionDistance);
+    thresholdFilter->SetLowerThreshold(-1e-5);
+    thresholdFilter->SetUpperThreshold(selectionDistance);
+    thresholdFilter->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
     thresholdFilter->SetInputArrayToProcess(0, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, DISTANCE_ARRAY_NAME);
 
     vtkNew<vtkGeometryFilter> geometryFilter;


### PR DESCRIPTION
This commit fixes removing use of API deprecated in kitware/vtk@62e5a71bf
(Add setters to vtkThreshold) and later removed in kitware/vtk@d933bb849
(vtkDeprecation: remove symbols deprecated in 9.1).

Error:

  SurfaceToolbox/DynamicModeler/Logic/vtkSlicerDynamicModelerSelectByPointsTool.cxx:423:22: error: ‘class vtkThreshold’ has no member named ‘ThresholdBetween’; did you mean ‘ThresholdType’?