### PR TITLE
ENH: Uniform remesh models with triangle strips

### DIFF
--- a/SurfaceToolbox/SurfaceToolbox.py
+++ b/SurfaceToolbox/SurfaceToolbox.py
@@ -406,7 +406,10 @@ class SurfaceToolboxLogic(ScriptedLoadableModuleLogic):
 
     import pyacvd
     import pyvista as pv
-    inputMesh = pv.wrap(inputModel.GetPolyData())
+    tri_filter = pv._vtk.vtkTriangleFilter()
+    tri_filter.SetInputData(inputModel.GetPolyData())
+    tri_filter.Update()
+    inputMesh = pv.wrap(tri_filter.GetOutput())
     clus = pyacvd.Clustering(inputMesh)
     if subdivide > -1:
         clus.subdivide(subdivide)

--- a/SurfaceToolbox/SurfaceToolbox.py
+++ b/SurfaceToolbox/SurfaceToolbox.py
@@ -406,7 +406,8 @@ class SurfaceToolboxLogic(ScriptedLoadableModuleLogic):
 
     import pyacvd
     import pyvista as pv
-    tri_filter = pv._vtk.vtkTriangleFilter()
+    tri_filter = vtk.vtkTriangleFilter()
+
     tri_filter.SetInputData(inputModel.GetPolyData())
     tri_filter.Update()
     inputMesh = pv.wrap(tri_filter.GetOutput())

--- a/SurfaceToolbox/SurfaceToolbox.py
+++ b/SurfaceToolbox/SurfaceToolbox.py
@@ -407,7 +407,6 @@ class SurfaceToolboxLogic(ScriptedLoadableModuleLogic):
     import pyacvd
     import pyvista as pv
     tri_filter = vtk.vtkTriangleFilter()
-
     tri_filter.SetInputData(inputModel.GetPolyData())
     tri_filter.Update()
     inputMesh = pv.wrap(tri_filter.GetOutput())


### PR DESCRIPTION
Models created using the Segmentations module use polygons to represent triangles, whereas the Model Maker module uses triangle strips. Uniform remesh using PyACVD failed if the model contained triangle strips instead of triangles as polygons. Fixed by converting triangle strips to triangles using vtkTriangleFilter.