### PR TITLE
COMP: Fix deprecation warnings by explicitly calling vtkStdString::c_str()

### DIFF
--- a/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx
+++ b/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx
@@ -774,7 +774,7 @@ void qSlicerDynamicModelerModuleWidget::updateMRMLFromWidget()
     std::string attributeName = parameterSelector->property("AttributeName").toString().toStdString();
     if (attributeName != "")
       {
-      d->DynamicModelerNode->SetAttribute(attributeName.c_str(), value.ToString());
+      d->DynamicModelerNode->SetAttribute(attributeName.c_str(), value.ToString().c_str());
       }
     }
 }


### PR DESCRIPTION
This commit fixes the following warning:

```
/path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx: In member function ‘void qSlicerDynamicModelerModuleWidget::updateMRMLFromWidget()’: /path/to/Slicer-Release/SurfaceToolbox/DynamicModeler/qSlicerDynamicModelerModuleWidget.cxx:777:82: warning: ‘vtkStdString::operator const char*()’ is deprecated: Call `.c_str()` explicitly [-Wdeprecated-declarations]
  777 |       d->DynamicModelerNode->SetAttribute(attributeName.c_str(), value.ToString());
      |
```