### PR TITLE
ENH: Prepare for Qt6 build with AUTOMOC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.13.4)
 
 project(SurfaceToolbox)
 
+list(APPEND CMAKE_AUTOUIC_SEARCH_PATHS
+  ${CMAKE_CURRENT_LIST_DIR}/DynamicModeler/Resources/UI
+  ${CMAKE_CURRENT_LIST_DIR}/SurfaceToolbox/Resources/UI
+)
+
 #-----------------------------------------------------------------------------
 # Extension dependencies
 find_package(Slicer REQUIRED)


### PR DESCRIPTION
This prepares the build environment to support when Slicer moves to build with AUTOMOC.
