### PR TITLE
Remove orphan points from Dynamic Modeler ROI Cut and Plane Cut outputs

### DIFF
--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerBoundaryCutTool.cxx
@@ -140,6 +140,8 @@ vtkSlicerDynamicModelerBoundaryCutTool::vtkSlicerDynamicModelerBoundaryCutTool()
   this->ClipPolyData->SetInputConnection(this->InputModelToWorldTransformFilter->GetOutputPort());
   this->ClipPolyData->SetValue(epsilon);
   this->ClipPolyData->InsideOutOn();
+  // Enabling GenerateClippedOutputOn generates orphan points in the output, but we
+  // remove them later with OutputCleanFilter.
   this->ClipPolyData->GenerateClippedOutputOn();
 
   this->Connectivity = vtkSmartPointer<vtkPolyDataConnectivityFilter>::New();

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerCurveCutTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerCurveCutTool.cxx
@@ -279,6 +279,8 @@ bool vtkSlicerDynamicModelerCurveCutTool::RunInternal(vtkMRMLDynamicModelerNode*
     this->ClipFilter->SetInputConnection(this->SelectionFilter->GetOutputPort());
     this->OutputWorldToModelTransformFilter->SetInputConnection(this->ConnectivityFilter->GetOutputPort());
     this->ClipFilter->SetGenerateClippedOutput(outputOutsideModelNode != nullptr);
+    // Enabling GenerateClippedOutputOn generates orphan points in the output, but they do not cause issues,
+    // because the connectivity filter removes them.
     if (outputInsideModelNode)
       {
       this->ConnectivityFilter->SetInputConnection(this->ClipFilter->GetOutputPort());

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.cxx
@@ -30,6 +30,7 @@
 
 // VTK includes
 #include <vtkAppendPolyData.h>
+#include <vtkCleanPolyData.h>
 #include <vtkClipClosedSurface.h>
 #include <vtkClipPolyData.h>
 #include <vtkCollection.h>
@@ -156,6 +157,23 @@ vtkSlicerDynamicModelerPlaneCutTool::vtkSlicerDynamicModelerPlaneCutTool()
   this->PlaneClipper = vtkSmartPointer<vtkClipPolyData>::New();
   this->PlaneClipper->SetInputConnection(this->InputModelToWorldTransformFilter->GetOutputPort());
   this->PlaneClipper->SetValue(0.0);
+
+  // vtkClipPolyData leaves points in the output that are not used in any cells.
+  // Set up cleaner filter to remove those (and do nothing else).
+
+  this->OutputPositiveCleanFilter = vtkSmartPointer<vtkCleanPolyData>::New();
+  this->OutputPositiveCleanFilter->SetInputConnection(this->PlaneClipper->GetOutputPort());
+  this->OutputPositiveCleanFilter->PointMergingOff();
+  this->OutputPositiveCleanFilter->ConvertLinesToPointsOff();
+  this->OutputPositiveCleanFilter->ConvertPolysToLinesOff();
+  this->OutputPositiveCleanFilter->ConvertStripsToPolysOff();
+
+  this->OutputNegativeCleanFilter = vtkSmartPointer<vtkCleanPolyData>::New();
+  this->OutputNegativeCleanFilter->SetInputConnection(this->PlaneClipper->GetClippedOutputPort());
+  this->OutputNegativeCleanFilter->PointMergingOff();
+  this->OutputNegativeCleanFilter->ConvertLinesToPointsOff();
+  this->OutputNegativeCleanFilter->ConvertPolysToLinesOff();
+  this->OutputNegativeCleanFilter->ConvertStripsToPolysOff();
 
   this->OutputPositiveWorldToModelTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->OutputPositiveWorldToModelTransform = vtkSmartPointer<vtkGeneralTransform>::New();
@@ -380,7 +398,6 @@ bool vtkSlicerDynamicModelerPlaneCutTool::RunInternal(vtkMRMLDynamicModelerNode*
     {
     this->PlaneClipper->GenerateClippedOutputOn();
     }
-  this->PlaneClipper->Update();
 
   bool capSurface = this->GetNthInputParameterValue(0, surfaceEditorNode).ToInt() != 0;
   vtkNew<vtkPolyData> endCapPolyData;
@@ -392,7 +409,8 @@ bool vtkSlicerDynamicModelerPlaneCutTool::RunInternal(vtkMRMLDynamicModelerNode*
   if (outputPositiveModelNode)
     {
     vtkNew<vtkPolyData> outputMesh;
-    outputMesh->ShallowCopy(this->PlaneClipper->GetOutput());
+    this->OutputPositiveCleanFilter->Update();
+    outputMesh->ShallowCopy(this->OutputPositiveCleanFilter->GetOutput());
     if (capSurface)
       {
       vtkNew<vtkAppendPolyData> appendEndCap;
@@ -414,7 +432,8 @@ bool vtkSlicerDynamicModelerPlaneCutTool::RunInternal(vtkMRMLDynamicModelerNode*
   if (outputNegativeModelNode)
     {
     vtkNew<vtkPolyData> outputMesh;
-    outputMesh->ShallowCopy(this->PlaneClipper->GetClippedOutput());
+    this->OutputNegativeCleanFilter->Update();
+    outputMesh->ShallowCopy(this->OutputNegativeCleanFilter->GetOutput());
     if (capSurface)
       {
       vtkNew<vtkReverseSense> reverseSense;

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerPlaneCutTool.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 class vtkClipPolyData;
+class vtkCleanPolyData;
 class vtkDataObject;
 class vtkGeneralTransform;
 class vtkGeometryFilter;
@@ -77,9 +78,11 @@ protected:
 
   vtkSmartPointer<vtkClipPolyData>            PlaneClipper;
 
+  vtkSmartPointer<vtkCleanPolyData>           OutputPositiveCleanFilter;
   vtkSmartPointer<vtkTransformPolyDataFilter> OutputPositiveWorldToModelTransformFilter;
   vtkSmartPointer<vtkGeneralTransform>        OutputPositiveWorldToModelTransform;
 
+  vtkSmartPointer<vtkCleanPolyData>           OutputNegativeCleanFilter;
   vtkSmartPointer<vtkTransformPolyDataFilter> OutputNegativeWorldToModelTransformFilter;
   vtkSmartPointer<vtkGeneralTransform>        OutputNegativeWorldToModelTransform;
 

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerROICutTool.cxx
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerROICutTool.cxx
@@ -32,6 +32,7 @@
 
 // VTK includes
 #include <vtkAppendPolyData.h>
+#include <vtkCleanPolyData.h>
 #include <vtkClipPolyData.h>
 #include <vtkCommand.h>
 #include <vtkGeneralTransform.h>
@@ -136,14 +137,31 @@ vtkSlicerDynamicModelerROICutTool::vtkSlicerDynamicModelerROICutTool()
   this->ROIClipper = vtkSmartPointer<vtkClipPolyData>::New();
   this->ROIClipper->SetInputConnection(this->InputModelToWorldTransformFilter->GetOutputPort());
 
+  // vtkClipPolyData leaves points in the output that are not used in any cells.
+  // Set up cleaner filter to remove those (and do nothing else).
+
+  this->OutputInsideCleaner = vtkSmartPointer<vtkCleanPolyData>::New();
+  this->OutputInsideCleaner->SetInputConnection(this->ROIClipper->GetOutputPort());
+  this->OutputInsideCleaner->PointMergingOff();
+  this->OutputInsideCleaner->ConvertLinesToPointsOff();
+  this->OutputInsideCleaner->ConvertPolysToLinesOff();
+  this->OutputInsideCleaner->ConvertStripsToPolysOff();
+
+  this->OutputOutsideCleaner = vtkSmartPointer<vtkCleanPolyData>::New();
+  this->OutputOutsideCleaner->SetInputConnection(this->ROIClipper->GetClippedOutputPort());
+  this->OutputOutsideCleaner->PointMergingOff();
+  this->OutputOutsideCleaner->ConvertLinesToPointsOff();
+  this->OutputOutsideCleaner->ConvertPolysToLinesOff();
+  this->OutputOutsideCleaner->ConvertStripsToPolysOff();
+
   this->OutputInsideWorldToModelTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->OutputInsideWorldToModelTransform = vtkSmartPointer<vtkGeneralTransform>::New();
-  this->OutputInsideWorldToModelTransformFilter->SetInputConnection(this->ROIClipper->GetOutputPort());
+  this->OutputInsideWorldToModelTransformFilter->SetInputConnection(this->OutputInsideCleaner->GetOutputPort());
   this->OutputInsideWorldToModelTransformFilter->SetTransform(this->OutputInsideWorldToModelTransform);
 
   this->OutputOutsideWorldToModelTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->OutputOutsideWorldToModelTransform = vtkSmartPointer<vtkGeneralTransform>::New();
-  this->OutputOutsideWorldToModelTransformFilter->SetInputConnection(this->ROIClipper->GetClippedOutputPort());
+  this->OutputOutsideWorldToModelTransformFilter->SetInputConnection(this->OutputOutsideCleaner->GetOutputPort());
   this->OutputOutsideWorldToModelTransformFilter->SetTransform(this->OutputOutsideWorldToModelTransform);
 }
 

--- a/DynamicModeler/Logic/vtkSlicerDynamicModelerROICutTool.h
+++ b/DynamicModeler/Logic/vtkSlicerDynamicModelerROICutTool.h
@@ -26,6 +26,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 
+class vtkCleanPolyData;
 class vtkClipPolyData;
 class vtkGeneralTransform;
 class vtkMRMLDynamicModelerNode;
@@ -81,6 +82,9 @@ protected:
   vtkSmartPointer<vtkGeneralTransform>        InputModelNodeToWorldTransform;
 
   vtkSmartPointer<vtkClipPolyData>            ROIClipper;
+
+  vtkSmartPointer<vtkCleanPolyData>           OutputInsideCleaner;
+  vtkSmartPointer<vtkCleanPolyData>           OutputOutsideCleaner;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> OutputInsideWorldToModelTransformFilter;
   vtkSmartPointer<vtkGeneralTransform>        OutputInsideWorldToModelTransform;


### PR DESCRIPTION
Dynamic Modeler module's ROI Cut tool and Plane Cut tool use vtkClipPolyData, which can leave orphan points (points that are not used in any cells) in its output. The points are not exactly the same as the input points (coordinates are, but point IDs are not) and they are only preserved in certain cases (e.g., when clipped points are requested), therefore the orphan points are not reliable usable for anything and so they are not worth preserving. This is confirmed by testing the filter and also discussed at https://discourse.vtk.org/t/vtkclippolydata-has-different-behaviors-in-vtk-8-2-0-and-in-vtk-9-4-0/15626.

Since having orphan points in the output is unexpected and caused errors in subsequent processing, clean polydata filter is applied to the output to remove the orphan points.

fixes https://github.com/Slicer/Slicer/issues/8777