### PR TITLE
COMP: Remove unused include

### DIFF
--- a/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.cxx
+++ b/DynamicModeler/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDynamicModelerPlugin.cxx
@@ -47,7 +47,6 @@
 #include <vtkMRMLDynamicModelerNode.h>
 
 // Terminologies includes
-#include "qSlicerTerminologyItemDelegate.h"
 #include "vtkSlicerTerminologiesModuleLogic.h"
 
 // MRML widgets includes


### PR DESCRIPTION
qSlicerTerminologyItemDelegate.h is not used in qSlicerSubjectHierarchyDynamicModelerPlugin.